### PR TITLE
Do not run the service as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,10 @@ RUN go build -ldflags="-w -s" -o dist/server main.go
 # AWF #
 #######
 
-FROM alpine as awf
+FROM alpine:latest as awf
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+USER appuser
 
 # Copy `audiowaveform` dependencies.
 COPY --from=bbc /deps /


### PR DESCRIPTION
I'm not entirely sure how to test this, the container runs fine locally and I can hit the hello world endpoint, but the waveform endpoint just returns 500s every time.

I ran the container after building it using:

```bash
docker run -it -p 0.0.0.0:43254:8888/tcp --rm awf:latest
```

But this is the response I get back :confused: 

```
➜  projects http --json POST http://0.0.0.0:43254/waveform '{"identifier":"8efe7cd6-bd5c-421b-806f-e67259d31fcc","url":"https://mp3d.jamendo.com/download/track/26736/mp32","duration":242000,"counts":[1]}'
HTTP/1.1 500 Internal Server Error
Content-Length: 52
Content-Type: text/plain; charset=utf-8
Date: Tue, 22 Feb 2022 20:31:39 GMT



+-----------------------------------------+
| NOTE: binary data not shown in terminal |
+-----------------------------------------+
```

If there is indeed a problem I'd suspect it has to do somehow with the permissions for _something_ (I just don't know what). We're copying everything as the new user, so that should be fine, and presumably as long as the Go binary actually runs (which I can see it is in the `docker run` output) then I don't know where the permissions issue would be :thinking: 